### PR TITLE
fix: ensure Uint8Array type is returned by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,9 @@ export function decodeUint8ArrayList (buf: Uint8ArrayList, offset: number): numb
   throw new RangeError('Could not decode varint')
 }
 
+export function encode (value: number): Uint8Array
+export function encode (value: number, buf: Uint8Array, offset?: number): Uint8Array
+export function encode (value: number, buf: Uint8ArrayList, offset?: number): Uint8ArrayList
 export function encode <T extends Uint8Array | Uint8ArrayList = Uint8Array> (value: number, buf?: T, offset: number = 0): T {
   if (buf == null) {
     buf = allocUnsafe(encodingLength(value)) as T

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -142,6 +142,12 @@ describe('uint8-varint', () => {
     }).to.throw(RangeError)
   })
 
+  it('should encode to Uint8Array by default', () => {
+    const buf: ArrayLike<number> = varint.encode(1234)
+
+    expect(buf).to.equalBytes([0xD2, 0x09])
+  })
+
   function randint (range: number): number {
     return Math.floor(Math.random() * range)
   }


### PR DESCRIPTION
If a buffer isn't passed a `Uint8Array` will be allocated, but if you type the return value it overrides the default generic type so break the various call signatures out into method overloads.